### PR TITLE
Migrate asusctl source to OpenGamingCollective on GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows Linux Mint release versioning with patch numbers.
 
 ## [Unreleased]
 
+### Changed
+- Installer: clone `asusctl` from its new home at `https://github.com/OpenGamingCollective/asusctl` (the project migrated from GitLab to the OpenGamingCollective on GitHub, where future development happens). `supergfxctl` remains on GitLab.
+- README: point asusctl source and issue links to the OGC GitHub repository.
+
+### Thanks
+- Thanks to @farfalk for reporting the asusctl OGC migration in issue #6.
+
 ## [22.3.1] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASUS Linux Tools Installer for Linux Mint
 
-An automated installation script for [asusctl](https://gitlab.com/asus-linux/asusctl) and [supergfxctl](https://gitlab.com/asus-linux/supergfxctl) on ASUS ROG/TUF laptops running **Linux Mint**.
+An automated installation script for [asusctl](https://github.com/OpenGamingCollective/asusctl) and [supergfxctl](https://gitlab.com/asus-linux/supergfxctl) on ASUS ROG/TUF laptops running **Linux Mint**.
 
 ## 🚀 Features
 
@@ -271,7 +271,7 @@ When reporting issues, please include:
 
 For more help, visit:
 - [ASUS Linux Community](https://asus-linux.org/)
-- [asusctl GitLab Issues](https://gitlab.com/asus-linux/asusctl/-/issues)
+- [asusctl GitHub Issues](https://github.com/OpenGamingCollective/asusctl/issues)
 - [supergfxctl GitLab Issues](https://gitlab.com/asus-linux/supergfxctl/-/issues)
 
 ## 📄 License

--- a/install-asus-linux.sh
+++ b/install-asus-linux.sh
@@ -430,7 +430,7 @@ install_asusctl() {
     # Clone or update asusctl
     if [ ! -d "asusctl" ]; then
         print_status "Cloning asusctl repository..."
-        git clone https://gitlab.com/asus-linux/asusctl.git
+        git clone https://github.com/OpenGamingCollective/asusctl.git
     else
         print_status "Updating asusctl repository..."
         cd asusctl


### PR DESCRIPTION
## Summary

`asusctl` has migrated from GitLab (`asus-linux/asusctl`) to the [OpenGamingCollective on GitHub](https://github.com/OpenGamingCollective/asusctl), where future development now happens. The old GitLab repo is frozen and carries an OGC migration notice. `supergfxctl` has **not** migrated and remains on GitLab.

Closes #6.

## Changes
- **Installer** (`install-asus-linux.sh`): clone `asusctl` from `github.com/OpenGamingCollective/asusctl`.
- **README**: update asusctl source and issue-tracker links to the OGC repo.
- **CHANGELOG**: document the migration under `[Unreleased]`.

## Verification
- New repo default branch is `main`, so the existing `git reset --hard origin/main` update path still works.
- Confirmed all data files the installer relies on (`data/asusd.*`, `rog-aura/data/aura_support.ron`, `rog-control-center/data/*`, `Cargo.toml`) exist with identical layout in the new repo.
- `bash -n` passes for both scripts.